### PR TITLE
feat(view-animation-timings): Create animation timings for sequencing view load order

### DIFF
--- a/src/router-view.js
+++ b/src/router-view.js
@@ -91,7 +91,7 @@ export class RouterView {
      * @description bind viewModel, and add view to this viewSlot
      */
     function next() {
-      viewPortInstruction.controller.view.bind(viewPortInstruction.controller.model);
+      viewPortInstruction.controller.automate();
       viewSlot.add(viewPortInstruction.controller.view);
     }
   }

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -1,15 +1,14 @@
 import {Container, inject} from 'aurelia-dependency-injection';
-import {ViewSlot, ViewLocator, customElement, noView, BehaviorInstruction} from 'aurelia-templating';
-import {bindable} from 'aurelia-framework';
+import {ViewSlot, ViewLocator, customElement, noView, BehaviorInstruction, bindable} from 'aurelia-templating';
 import {Router} from 'aurelia-router';
 import {Origin} from 'aurelia-metadata';
 import {DOM} from 'aurelia-pal';
 
-var timingFunctions = {
+const timingFunctions = {
   // animate the next view in before removing the current view;
   before(viewSlot, view, callback) {
     let promised = callback();
-    if (view) promised ? promised.then(()=> viewSlot.remove(view)) : viewSlot.remove(view);
+    Promise.resolve(promised).then(()=> viewSlot.remove(view));
   },
   // animate the next view at the same time the current view is removed
   with(viewSlot, view, callback) {
@@ -19,7 +18,7 @@ var timingFunctions = {
   // animate the next view in after the current view has been removed
   after(viewSlot, view, callback) {
     let promised = viewSlot.removeAll(true);
-    promised ? promised.then(callback) : callback();
+    Promise.resolve(promised).then(callback);
   }
 };
 
@@ -72,8 +71,6 @@ export class RouterView {
   }
 
   swap(viewPortInstruction) {
-
-    let self = this;
     let view = this.view;
     let viewSlot = this.viewSlot;
     let timingFunction = this.animationTiming in timingFunctions
@@ -86,13 +83,10 @@ export class RouterView {
 
     this.view = viewPortInstruction.controller.view;
 
-    /**
-     * Function(): next
-     * @description bind viewModel, and add view to this viewSlot
-     */
     function next() {
       viewPortInstruction.controller.automate();
       viewSlot.add(viewPortInstruction.controller.view);
     }
   }
+
 }

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -4,7 +4,7 @@ import {Router} from 'aurelia-router';
 import {Origin} from 'aurelia-metadata';
 import {DOM} from 'aurelia-pal';
 
-const timingFunctions = {
+const swapStrategies = {
   default: 'before',
   // animate the next view in before removing the current view;
   before(viewSlot, view, callback) {
@@ -27,7 +27,7 @@ const timingFunctions = {
 @noView
 @inject(DOM.Element, Container, ViewSlot, Router, ViewLocator)
 export class RouterView {
-  @bindable animationTiming = timingFunctions[timingFunctions.default];
+  @bindable viewSwap = swapStrategies[swapStrategies.default];
 
   constructor(element, container, viewSlot, router, viewLocator) {
     this.element = element;
@@ -74,12 +74,12 @@ export class RouterView {
   swap(viewPortInstruction) {
     let view = this.view;
     let viewSlot = this.viewSlot;
-    let timingFunction = this.animationTiming in timingFunctions
-      ? timingFunctions[this.animationTiming]
-      : timingFunctions.after;
+    let swapStrategy = this.swapView in swapStrategies
+      ? swapStrategies[this.swapView]
+      : swapStrategies[swapStrategies.default];
 
-    if (timingFunction) {
-      timingFunction(viewSlot, view, next);
+    if (swapStrategy) {
+      swapStrategy(viewSlot, view, next);
     }
 
     this.view = viewPortInstruction.controller.view;

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -27,7 +27,7 @@ const swapStrategies = {
 @noView
 @inject(DOM.Element, Container, ViewSlot, Router, ViewLocator)
 export class RouterView {
-  @bindable viewSwap = swapStrategies[swapStrategies.default];
+  @bindable swapOrder = swapStrategies[swapStrategies.default];
 
   constructor(element, container, viewSlot, router, viewLocator) {
     this.element = element;
@@ -74,8 +74,8 @@ export class RouterView {
   swap(viewPortInstruction) {
     let view = this.view;
     let viewSlot = this.viewSlot;
-    let swapStrategy = this.swapView in swapStrategies
-      ? swapStrategies[this.swapView]
+    let swapStrategy = this.swapOrder in swapStrategies
+      ? swapStrategies[this.swapOrder]
       : swapStrategies[swapStrategies.default];
 
     if (swapStrategy) {

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -5,6 +5,7 @@ import {Origin} from 'aurelia-metadata';
 import {DOM} from 'aurelia-pal';
 
 const timingFunctions = {
+  default: 'before',
   // animate the next view in before removing the current view;
   before(viewSlot, view, callback) {
     let promised = callback();
@@ -26,7 +27,7 @@ const timingFunctions = {
 @noView
 @inject(DOM.Element, Container, ViewSlot, Router, ViewLocator)
 export class RouterView {
-  @bindable animationTiming = 'after';
+  @bindable animationTiming = timingFunctions[timingFunctions.default];
 
   constructor(element, container, viewSlot, router, viewLocator) {
     this.element = element;


### PR DESCRIPTION
Create bindable attribute `animation-timing="before | with | after"`
Possible values
 - default: 'after'
 - before: Allows the next view to be added to the viewSlot, before the last view is removed. 
 - with: Allows the next view to the viewSlot while removing the last view
 - after: Allows the next view to be added to the viewSlot after the last view is finished being removed