### PR TITLE
fix(router-view): incorrect timing of viewslot removes when swapping

### DIFF
--- a/src/router-view.js
+++ b/src/router-view.js
@@ -88,72 +88,72 @@ export class RouterView {
       viewSlot: this.viewSlot
     };
 
-    return Promise.resolve(this.composeLayout(layoutInstruction))
-    .then(layoutView => {
-      let viewStrategy = this.viewLocator.getViewStrategy(component.view || viewModel);
-
-      if (viewStrategy) {
-        viewStrategy.makeRelativeTo(Origin.get(component.router.container.viewModel.constructor).moduleId);
-      }
-
-      return metadata.load(childContainer, viewModelResource.value, null, viewStrategy, true)
-      .then(viewFactory => {
-        if (!this.compositionTransactionNotifier) {
-          this.compositionTransactionOwnershipToken = this.compositionTransaction.tryCapture();
-        }
-
-        viewPortInstruction.layout = layoutView ? layoutView.view || layoutView : undefined;
-
-        viewPortInstruction.controller = metadata.create(childContainer,
-          BehaviorInstruction.dynamic(
-            this.element,
-            viewModel,
-            viewFactory
-          )
-        );
-
-        if (waitToSwap) {
-          return;
-        }
-
-        this.swap(viewPortInstruction);
-      });
-    });
-  }
-
-  composeLayout(instruction) {
-    if (instruction.viewModel || instruction.view) {
-      return this.compositionEngine.compose(instruction);
+    let viewStrategy = this.viewLocator.getViewStrategy(component.view || viewModel);
+    if (viewStrategy) {
+      viewStrategy.makeRelativeTo(Origin.get(component.router.container.viewModel.constructor).moduleId);
     }
 
-    return undefined;
+    return metadata.load(childContainer, viewModelResource.value, null, viewStrategy, true)
+    .then(viewFactory => {
+      if (!this.compositionTransactionNotifier) {
+        this.compositionTransactionOwnershipToken = this.compositionTransaction.tryCapture();
+      }
+
+      if (layoutInstruction.viewModel || layoutInstruction.view) {
+        viewPortInstruction.layoutInstruction = layoutInstruction;
+      }
+
+      viewPortInstruction.controller = metadata.create(childContainer,
+        BehaviorInstruction.dynamic(
+          this.element,
+          viewModel,
+          viewFactory
+        )
+      );
+
+      if (waitToSwap) {
+        return;
+      }
+
+      this.swap(viewPortInstruction);
+    });
   }
 
   swap(viewPortInstruction) {
     let work = () => {
       let previousView = this.view;
       let swapStrategy;
-      let layout = viewPortInstruction.layout;
-      let viewSlot = layout ? new ViewSlot(layout.firstChild, false) : this.viewSlot;
-
-      if (layout) {
-        viewSlot.attached();
-      }
+      let viewSlot = this.viewSlot;
+      let layoutInstruction = viewPortInstruction.layoutInstruction;
 
       swapStrategy = this.swapOrder in swapStrategies
                   ? swapStrategies[this.swapOrder]
                   : swapStrategies.after;
 
       swapStrategy(viewSlot, previousView, () => {
-        if (layout) {
-          ShadowDOM.distributeView(viewPortInstruction.controller.view, layout.slots, viewSlot);
-          this._notify();
+        let waitForView;
+
+        if (layoutInstruction) {
+          if (!layoutInstruction.viewModel) {
+            // createController chokes if there's no viewmodel, so create a dummy one
+            // could possibly check if there was no VM and don't use compose, just create a viewfactory -> view?
+            layoutInstruction.viewModel = {};
+          }
+
+          waitForView = this.compositionEngine.createController(layoutInstruction).then(layout => {
+            ShadowDOM.distributeView(viewPortInstruction.controller.view, layout.slots || layout.view.slots);
+            return layout.view || layout;
+          });
         } else {
-          return Promise.resolve(viewSlot.add(viewPortInstruction.controller.view)).then(() => { this._notify(); });
+          waitForView = Promise.resolve(viewPortInstruction.controller.view);
         }
 
-        this.view = viewPortInstruction.controller.view;
-        return Promise.resolve();
+        return waitForView.then(newView => {
+          this.view = newView;
+          return viewSlot.add(newView);
+        }).then(() => {
+          this._notify();
+        });
       });
     };
 

--- a/test/router-view.spec.js
+++ b/test/router-view.spec.js
@@ -30,7 +30,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-default-slot' });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content);
@@ -42,7 +42,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-default-slot', layoutView: 'test/layout-default-slot.html' });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content);
@@ -55,7 +55,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-default-slot', layoutViewModel: 'test/layout-default-slot' });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content);
@@ -69,7 +69,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-default-slot', layoutView: 'test/layout-default-slot-alt.html', layoutViewModel: 'test/layout-default-slot' });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content);
@@ -83,7 +83,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-named-slots', layoutView: 'test/layout-named-slots.html' });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content + '\n' + testConstants.content);
@@ -100,7 +100,7 @@ describe('router-view', () => {
     });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.element.innerText).toContain(testConstants.content);
@@ -113,7 +113,7 @@ describe('router-view', () => {
     component = withDefaultViewport({ moduleId: 'test/module-default-slot', layoutViewModel: 'test/layout-default-slot', layoutModel: 1 });
     component.create()
     .then(() => {
-      return component.viewModel.router.navigate('route');
+      return component.viewModel.router.navigate('route').then(wait);
     })
     .then(() => {
       expect(component.viewModel.viewSlot.children[0].controller.viewModel.value).toBe(1);
@@ -121,6 +121,14 @@ describe('router-view', () => {
     .then(done);
   });
 });
+
+function wait() {
+  return new Promise((res) => {
+    setTimeout(() => {
+      res();
+    }, 250);
+  });
+}
 
 function withDefaultViewport(routeConfig) {
   let component = StageComponent


### PR DESCRIPTION
This fixes a couple of issues - the timing on the view-slots as a consequence of using `compose` (which manipulates the view-slot) and also a potential bug where the wrong view was being assigned to the router-view's `view` property when using a layout which might have meant the viewslot would attempt to remove a view that wasn't in the slot.

All tests pass (actually I had to add a delay on the tests as the `navigate` method was resolving it's promise before the swap was finished - is this expected, I assume so since navigation actually worked, it's just the swap that is still ongoing?)

I've also checked with all swaps with enter/leave animations and they work correctly