### PR TITLE
extract viewModelLocation into separate function

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,12 +1,16 @@
 System.config({
-  defaultJSExtensions: true,
-  paths: {
-    "github:*": "jspm_packages/github/*",
+  "transpiler": "traceur",
+  "paths": {
+    "github:*": "jspm_packages/github/*.js",
     "aurelia-templating-router/*": "dist/*",
-    "npm:*": "jspm_packages/npm/*"
+    "npm:*": "jspm_packages/npm/*.js",
+    "*": "*.js"
   },
+  "defaultJSExtensions": true
+});
 
-  map: {
+System.config({
+  "map": {
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0-rc.1.0.1",
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0",
     "aurelia-event-aggregator": "npm:aurelia-event-aggregator@1.0.0",
@@ -30,6 +34,8 @@ System.config({
     "babel": "npm:babel-core@5.8.38",
     "babel-runtime": "npm:babel-runtime@5.8.38",
     "core-js": "npm:core-js@2.4.1",
+    "traceur": "github:jmcriffey/bower-traceur@0.0.88",
+    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.4.1"
     },
@@ -212,3 +218,4 @@ System.config({
     }
   }
 });
+

--- a/package.json
+++ b/package.json
@@ -21,27 +21,16 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "aurelia-templating-router",
     "format": "amd",
     "directories": {
       "dist": "dist/amd"
-    },
-    "peerDependencies": {
-      "aurelia-dependency-injection": "^1.0.0",
-      "aurelia-logging": "^1.0.0",
-      "aurelia-metadata": "^1.0.0",
-      "aurelia-pal": "^1.0.0",
-      "aurelia-path": "^1.0.0",
-      "aurelia-router": "^1.0.1",
-      "aurelia-templating": "^1.0.0"
     },
     "dependencies": {
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-logging": "^1.0.0",
       "aurelia-metadata": "^1.0.0",
       "aurelia-pal": "^1.0.0",
-      "aurelia-path": "^1.0.0",
       "aurelia-router": "^1.0.1",
       "aurelia-templating": "^1.0.0"
     },
@@ -52,7 +41,9 @@
       "aurelia-testing": "^0.5.0",
       "babel": "babel-core@^5.8.24",
       "babel-runtime": "^5.8.24",
-      "core-js": "^2.0.3"
+      "core-js": "^2.0.3",
+      "traceur": "github:jmcriffey/bower-traceur@0.0.88",
+      "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.88"
     }
   },
   "dependencies": {

--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -1,8 +1,6 @@
 import {inject} from 'aurelia-dependency-injection';
 import {CompositionEngine} from 'aurelia-templating';
 import {RouteLoader, Router} from 'aurelia-router';
-import {relativeToFile} from 'aurelia-path';
-import {Origin} from 'aurelia-metadata';
 
 @inject(CompositionEngine)
 export class TemplatingRouteLoader extends RouteLoader {
@@ -11,10 +9,25 @@ export class TemplatingRouteLoader extends RouteLoader {
     this.compositionEngine = compositionEngine;
   }
 
+  /*
+   * Calculate the view model location
+   * By convention this is the responsibility of the Router, but if need be you can
+   * override this on a per application basis here
+   *
+   * @param router The router
+   * @param config The route config
+   * @returns {string} the view model file location
+  */
   viewModelLocation(router, config) {
-    return relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId);
+    return router.viewModelLocation(config);
   }
 
+  /*
+   * Loads the route
+   *
+   * @param router The router
+   * @param config The route config
+  */
   loadRoute(router, config) {
     let childContainer = router.container.createChild();
     let instruction = {

--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -11,10 +11,14 @@ export class TemplatingRouteLoader extends RouteLoader {
     this.compositionEngine = compositionEngine;
   }
 
+  viewModelLocation(router, config) {
+    return relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId);
+  }
+
   loadRoute(router, config) {
     let childContainer = router.container.createChild();
     let instruction = {
-      viewModel: relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId),
+      viewModel: this.viewModelLocation(router, config),
       childContainer: childContainer,
       view: config.view || config.viewStrategy,
       router: router


### PR DESCRIPTION
Make it easier to change the `ViewModel` module loading strategy used by the router so we are not constrained by the current `moduleId` strategy only.
