### PR TITLE
Allow router to override general strategy for locating view model

### DIFF
--- a/dist/aurelia-templating-router.js
+++ b/dist/aurelia-templating-router.js
@@ -232,10 +232,19 @@ export class TemplatingRouteLoader extends RouteLoader {
     this.compositionEngine = compositionEngine;
   }
 
+  findViewModelLocation(router, config) {
+    // allow router to override general strategy for locating view model
+    if (router.findViewModelLocation) {
+      return router.findViewModelLocation(config);
+    }    
+    let parentModuleId = Origin.get(router.container.viewModel.constructor).moduleId;
+    return relativeToFile(config.moduleId, parentModuleId);
+  }
+
   loadRoute(router, config) {
     let childContainer = router.container.createChild();
     let instruction = {
-      viewModel: relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId),
+      viewModel: this.findViewModelLocation(router, config),
       childContainer: childContainer,
       view: config.view || config.viewStrategy,
       router: router


### PR DESCRIPTION
Sometimes you want the Router to be able to apply a specific strategy for resolving view models, such as using a setting or a specific module pattern. 
