### PR TITLE
feat(templating-router): async property in route-href which prevents …

### DIFF
--- a/src/route-href.js
+++ b/src/route-href.js
@@ -10,7 +10,7 @@ const logger = LogManager.getLogger('route-href');
 @bindable({name: 'route', changeHandler: 'processChange'})
 @bindable({name: 'params', changeHandler: 'processChange'})
 @bindable({name: 'attribute', defaultValue: 'href'})
-@bindable({name: 'async', defaultValue: false})
+@bindable({name: 'asyncParam', defaultValue: false})
 @inject(Router, DOM.Element)
 export class RouteHref {
   constructor(router, element) {
@@ -21,6 +21,7 @@ export class RouteHref {
   bind() {
     this.isActive = true;
 
+    // With the async-param attribute set to true, undefined values of route parameters won't yield requirement errors.
     if (!!this.async) {
       let values = Object.keys(this.params).map(key => this.params[key]);
       if (values.includes(undefined)) {

--- a/src/route-href.js
+++ b/src/route-href.js
@@ -10,7 +10,7 @@ const logger = LogManager.getLogger('route-href');
 @bindable({name: 'route', changeHandler: 'processChange'})
 @bindable({name: 'params', changeHandler: 'processChange'})
 @bindable({name: 'attribute', defaultValue: 'href'})
-@bindable({name: 'asyncParam', defaultValue: false})
+@bindable({name: 'asyncParam', attribute: 'async-param', defaultValue: false})
 @inject(Router, DOM.Element)
 export class RouteHref {
   constructor(router, element) {
@@ -22,7 +22,7 @@ export class RouteHref {
     this.isActive = true;
 
     // With the async-param attribute set to true, undefined values of route parameters won't yield requirement errors.
-    if (!!this.async) {
+    if (!!this.asyncParam) {
       let values = Object.keys(this.params).map(key => this.params[key]);
       if (values.includes(undefined)) {
         return;

--- a/src/route-href.js
+++ b/src/route-href.js
@@ -10,6 +10,7 @@ const logger = LogManager.getLogger('route-href');
 @bindable({name: 'route', changeHandler: 'processChange'})
 @bindable({name: 'params', changeHandler: 'processChange'})
 @bindable({name: 'attribute', defaultValue: 'href'})
+@bindable({name: 'async', defaultValue: false})
 @inject(Router, DOM.Element)
 export class RouteHref {
   constructor(router, element) {
@@ -19,6 +20,14 @@ export class RouteHref {
 
   bind() {
     this.isActive = true;
+
+    if (!!this.async) {
+      let values = Object.keys(this.params).map(key => this.params[key]);
+      if (values.includes(undefined)) {
+        return;
+      }
+    }
+
     this.processChange();
   }
 


### PR DESCRIPTION
…errors for (yet) undefined params

Issue #21 noted error "A value is required for route parameters ... in route ..."
when the params data is available after an asynchronous call.
This feature adds the async property. If enabled, the bind method does not process the url
when the params include undefined values.
