### PR TITLE
Changes the route-href so that it can be used on custom elements

### DIFF
--- a/src/route-href.js
+++ b/src/route-href.js
@@ -43,7 +43,7 @@ export class RouteHref {
 
         let href = this.router.generate(this.route, this.params);
 
-        if (this.element.au.controller) {
+        if (this.element.au.controller) { 
           this.element.au.controller.viewModel.href = href;
         } else {
           this.element.setAttribute(this.attribute, href);

--- a/src/route-href.js
+++ b/src/route-href.js
@@ -42,7 +42,13 @@ export class RouteHref {
         }
 
         let href = this.router.generate(this.route, this.params);
-        this.element.setAttribute(this.attribute, href);
+
+        if (this.element.au.controller) {
+          this.element.au.controller.viewModel.href = href;
+        } else {
+          this.element.setAttribute(this.attribute, href);
+        }
+        
         return null;
       }).catch(reason => {
         logger.error(reason);

--- a/src/route-href.js
+++ b/src/route-href.js
@@ -44,7 +44,7 @@ export class RouteHref {
         let href = this.router.generate(this.route, this.params);
 
         if (this.element.au.controller) { 
-          this.element.au.controller.viewModel.href = href;
+          this.element.au.controller.viewModel[this.attribute] = href;
         } else {
           this.element.setAttribute(this.attribute, href);
         }


### PR DESCRIPTION
In relation to the issue by @thomas-darling (https://github.com/aurelia/templating-router/issues/36), I have modified the `route-href` custom attribute, so that it can be rationally applied to custom elements.



With this change existing behavior remain unchanged, however, when applied to a custom element, this will get an `href` property on its view-model having the generated route. Refer to the mentioned issue for a use-case scenario.