### PR TITLE
findViewModelLocation

### DIFF
--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -11,10 +11,20 @@ export class TemplatingRouteLoader extends RouteLoader {
     this.compositionEngine = compositionEngine;
   }
 
+  // enable router to define strategy for resolving View Model location
+  findViewModelLocation(router, config) {
+    // allow router to override general strategy for locating view model
+    if (router.findViewModelLocation) {
+      return router.findViewModelLocation(config);
+    }
+    let parentModuleId = Origin.get(router.container.viewModel.constructor).moduleId;
+    return relativeToFile(config.moduleId, parentModuleId);
+  }
+
   loadRoute(router, config) {
     let childContainer = router.container.createChild();
     let instruction = {
-      viewModel: relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId),
+      viewModel: this.findViewModelLocation(router, config),
       childContainer: childContainer,
       view: config.view || config.viewStrategy,
       router: router


### PR DESCRIPTION
TBH, it doesn't yet look ideal, since whenever I see two or more methods that take the same params, it is a sign they should reside in a separate class with those params as constructor args.

```js
findViewModelLocation(router, config) { ... }

loadRoute(router, config) {
 ...
}
```