### PR TITLE
(feat) add RouterViewLocator for locating the nearest router view

### DIFF
--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -3,6 +3,7 @@ import {CompositionEngine} from 'aurelia-templating';
 import {RouteLoader, Router} from 'aurelia-router';
 import {relativeToFile} from 'aurelia-path';
 import {Origin} from 'aurelia-metadata';
+import {RouterViewLocator} from './router-view';
 
 @inject(CompositionEngine)
 export class TemplatingRouteLoader extends RouteLoader {
@@ -19,6 +20,8 @@ export class TemplatingRouteLoader extends RouteLoader {
       view: config.view || config.viewStrategy,
       router: router
     };
+
+    childContainer.registerSingleton(RouterViewLocator);
 
     childContainer.getChildRouter = function() {
       let childRouter;

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -44,6 +44,7 @@ export class RouterView {
   @bindable layoutView;
   @bindable layoutViewModel;
   @bindable layoutModel;
+  element;
 
   constructor(element, container, viewSlot, router, viewLocator, compositionTransaction, compositionEngine) {
     this.element = element;
@@ -78,6 +79,8 @@ export class RouterView {
     let metadata = viewModelResource.metadata;
     let config = component.router.currentInstruction.config;
     let viewPort = config.viewPorts ? config.viewPorts[viewPortInstruction.name] : {};
+
+    childContainer.get(RouterViewLocator)._notify(this);
 
     // layoutInstruction is our layout viewModel
     let layoutInstruction = {
@@ -181,5 +184,30 @@ export class RouterView {
       this.compositionTransactionNotifier.done();
       this.compositionTransactionNotifier = null;
     }
+  }
+}
+
+/**
+* Locator which finds the nearest RouterView, relative to the current dependency injection container.
+*/
+export class RouterViewLocator {
+  
+  /**
+  * Creates an instance of the RouterViewLocator class.
+  */
+  constructor() {
+    this.promise = new Promise((resolve) => this.resolve = resolve);
+  }
+
+  /**
+  * Finds the nearest RouterView instance.
+  * @returns A promise that will be resolved with the located RouterView instance.
+  */
+  findNearest(): Promise<RouterView> {
+      return this.promise;
+  }
+
+  _notify(routerView: RouterView): void {
+      this.resolve(routerView);
   }
 }

--- a/test/layout-default-slot.js
+++ b/test/layout-default-slot.js
@@ -1,9 +1,21 @@
+import {inject} from 'aurelia-dependency-injection';
 import {testConstants} from '../test/test-constants';
+import {RouterViewLocator, RouterView} from 'src/router-view';
 
+@inject(RouterViewLocator)
 export class LayoutDefaultSlot {
   constants = testConstants;
 
+  constructor(routerViewLocator) {
+    routerViewLocator.findNearest().then(routerView => {
+      if (!this.activated && routerView instanceof RouterView) {
+        this.routerViewLocated = true;
+      }
+    });
+  }
+
   activate(value) {
+    this.activated = true;
     this.value = value;
   }
 }

--- a/test/router-view.spec.js
+++ b/test/router-view.spec.js
@@ -121,6 +121,18 @@ describe('router-view', () => {
     })
     .then(done);
   });
+
+  it('locates the view port before activating', done => {
+    component = withDefaultViewport({ moduleId: 'test/module-default-slot', layoutViewModel: 'test/layout-default-slot' });
+    component.create(bootstrap)
+    .then(() => {
+      return component.viewModel.router.navigate('route').then(wait);
+    })
+    .then(() => {
+      expect(component.viewModel.viewSlot.children[0].controller.viewModel.routerViewLocated).toBe(true);
+    })
+    .then(done);
+  });
 });
 
 function wait() {


### PR DESCRIPTION
This resolves https://github.com/aurelia/framework/issues/139.

Note that to avoid circular imports, `RouterViewLocator` must be in the same file as `RouterView`.