### PR TITLE
fix(templating-router): Silence Bluebirds runaway promise warning

### DIFF
--- a/src/router-view.js
+++ b/src/router-view.js
@@ -85,7 +85,7 @@ export class RouterView {
       );
 
       if (waitToSwap) {
-        return;
+        return null;
       }
 
       this.swap(viewPortInstruction);


### PR DESCRIPTION
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
By returning null rather than undefined, a warning is no longer thrown.

In the skeletons, we are silencing ALL Bluebird warnings to ignore this. That is no longer needed. 