### PR TITLE
feat(templating-router): optional viewports

### DIFF
--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -1,5 +1,5 @@
 import {inject} from 'aurelia-dependency-injection';
-import {CompositionEngine, useView, customElement} from 'aurelia-templating';
+import {CompositionEngine, useView, inlineView, customElement} from 'aurelia-templating';
 import {RouteLoader, Router} from 'aurelia-router';
 import {relativeToFile} from 'aurelia-path';
 import {Origin} from 'aurelia-metadata';
@@ -15,9 +15,13 @@ export class TemplatingRouteLoader extends RouteLoader {
   loadRoute(router, config) {
     let childContainer = router.container.createChild();
 
-    let viewModel = /\.html/.test(config.moduleId)
-      ? createDynamicClass(config.moduleId)
-      : relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId);
+    let viewModel = config === null
+      ? createEmptyClass()
+      : /\.html/.test(config.moduleId)
+        ? createDynamicClass(config.moduleId)
+        : relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId);
+    
+    config = config || {};
 
     let instruction = {
       viewModel: viewModel,
@@ -54,4 +58,11 @@ function createDynamicClass(moduleId) {
   }
 
   return DynamicClass;
+}
+
+function createEmptyClass() {
+  @inlineView('<template></template>')
+  class EmptyClass { }
+
+  return EmptyClass;
 }

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -47,7 +47,7 @@ export class RouterView {
     let viewModelResource = component.viewModelResource;
     let metadata = viewModelResource.metadata;
     let config = component.router.currentInstruction.config;
-    let viewPort = config.viewPorts ? config.viewPorts[viewPortInstruction.name] : {};
+    let viewPort = (config.viewPorts ? config.viewPorts[viewPortInstruction.name] : {}) || {};
 
     childContainer.get(RouterViewLocator)._notify(this);
 


### PR DESCRIPTION
Makes viewports optional in route configuration. Enables configuring viewports to be either empty or contain previous module.

Required by aurelia/templating-router/optional-viewports
Closes aurelia/router/issues/482