### PR TITLE
change(route-href): Generate route href on bind

### DIFF
--- a/src/route-href.js
+++ b/src/route-href.js
@@ -17,7 +17,7 @@ export class RouteHref {
     this.element = element;
   }
 
-  attached() {
+  bind() {
     this.isActive = true;
     this.processChange();
   }


### PR DESCRIPTION
There was a timing issue https://github.com/aurelia/templating-router/issues/46 that caused route-href to break when opening a page with child routers on first open. A temporary fix https://github.com/aurelia/templating-router/pull/56 was made that delayed generation of the route until the attached callback, when all requisite data was finally available. This solution remained a blocker https://github.com/aurelia/router/issues/552 for SSR. I've introduced another hopefully more robust fix https://github.com/aurelia/router/pull/555 that should allow us to return to the original behavior of generating a route on bind.

Resolves https://github.com/aurelia/templating-router/issues/46
Resolves https://github.com/aurelia/router/issues/552
Resolves https://github.com/aurelia/router/issues/306
Resolves https://github.com/aurelia/router/issues/169
Depends on https://github.com/aurelia/router/pull/555
Reverts https://github.com/aurelia/templating-router/pull/56