### PR TITLE
refactor(route-loader): remove unnecessary check for undefined RouteConfig

### DIFF
--- a/src/route-loader.js
+++ b/src/route-loader.js
@@ -27,8 +27,6 @@ export class TemplatingRouteLoader extends RouteLoader {
       viewModel = relativeToFile(config.moduleId, Origin.get(router.container.viewModel.constructor).moduleId);
     }
 
-    config = config || {};
-
     let instruction = {
       viewModel: viewModel,
       childContainer: childContainer,


### PR DESCRIPTION
I stumbled upon this line of code and noticed it wouldn't be executed under any circumstance. If this `config` variable is falsey, a `TypeError` will be thrown before this check is ever reached.