### PR TITLE
WIP feat(RouterView): ability to use class as moduleId

### DIFF
--- a/src/router-view.js
+++ b/src/router-view.js
@@ -9,12 +9,22 @@ import {DOM} from 'aurelia-pal';
 @noView
 @inject(DOM.Element, Container, ViewSlot, Router, ViewLocator, CompositionTransaction, CompositionEngine)
 export class RouterView {
+  /**@type {'before' | 'with' | 'after'} */
   @bindable swapOrder;
   @bindable layoutView;
   @bindable layoutViewModel;
   @bindable layoutModel;
   element;
 
+  /**
+   * @param {Element} element
+   * @param {Container} container
+   * @param {ViewSlot} viewSlot
+   * @param {Router} router
+   * @param {ViewLocator} viewLocator
+   * @param {CompositionTransaction} compositionTransaction
+   * @param {CompositionEngine} compositionEngine
+   */
   constructor(element, container, viewSlot, router, viewLocator, compositionTransaction, compositionEngine) {
     this.element = element;
     this.container = container;

--- a/test/router-view.spec.js
+++ b/test/router-view.spec.js
@@ -263,7 +263,7 @@ function configure(component, defaultRoute, routeConfig) {
     }
 
     aurelia.use.container.viewModel = {
-      configureRouter: /** @param {RouterConfiguration} config @param {Router} router */ (config, router) => {
+      configureRouter: (config, router) => {
         config.map(routeConfig);
       }
     };

--- a/test/router-view.spec.js
+++ b/test/router-view.spec.js
@@ -158,7 +158,7 @@ describe('router-view', () => {
       .then(done);
   });
 
-  fdescribe('classes as module id', () => {
+  describe('classes as module id', () => {
     it('uses class for route module id', (done) => {
       @inlineView('<template><span class="route-1">This is route 1</span></template>')
       class Route {}


### PR DESCRIPTION
Ability to use a class or a promise that resolves to a class to declare module id instead of a string

Example:

```js
export class App {

  message = 'Hello World!';

  configureRouter(config, router) {
    config.map([
      {
        route: 'route1',
        nav: true,
        viewPorts: { v1: { moduleId: Route1 }, v2: { moduleId: Route2 } },
      },
      {
        route: 'route2',
        nav: true,
        viewPorts: {
          v1: { moduleId: Route2 },
          v2: { moduleId: import('./route-3').then(m => m.Route3) }
        }
      },
      {
        route: 'route3',
        nav: true,
        moduleId: import('./route-3').then(m => m.Route3)
      }
    ])
    config.mapUnknownRoutes({ route: '*', redirect: 'route1' });
    this.router = router;
  }
}
```

Demo:

https://stackblitz.com/edit/statically-aurelia-qu174c?file=app.js

Requires https://github.com/aurelia/router/pull/586 to support TypeScript user

@PWKad @davismj @EisenbergEffect 