### PR TITLE
Updated dependencies for aurelia-binding (removed 1.x dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "dist": "dist/amd"
     },
     "peerDependencies": {
-      "aurelia-binding": "^1.3.0 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-logging": "^1.0.0",
       "aurelia-metadata": "^1.0.0",
@@ -38,7 +38,7 @@
       "aurelia-templating": "^1.5.0"
     },
     "dependencies": {
-      "aurelia-binding": "^1.3.0 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-logging": "^1.0.0",
       "aurelia-metadata": "^1.0.0",
@@ -59,7 +59,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.3.0 || ^2.0.0",
+    "aurelia-binding": "^2.0.0",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-logging": "^1.0.0",
     "aurelia-metadata": "^1.0.0",


### PR DESCRIPTION
To be able to install via JSPM (which doesn't support comparator sets for versioning)