### PR TITLE
fix(RouterView, RouteHref): delay element injection

### DIFF
--- a/src/route-href.js
+++ b/src/route-href.js
@@ -10,8 +10,12 @@ const logger = LogManager.getLogger('route-href');
 @bindable({name: 'route', changeHandler: 'processChange', primaryProperty: true})
 @bindable({name: 'params', changeHandler: 'processChange'})
 @bindable({name: 'attribute', defaultValue: 'href'})
-@inject(Router, DOM.Element)
 export class RouteHref {
+
+  static inject() {
+    return [Router, DOM.Element];
+  }
+
   constructor(router, element) {
     this.router = router;
     this.element = element;

--- a/src/router-view.js
+++ b/src/router-view.js
@@ -7,8 +7,12 @@ import {DOM} from 'aurelia-pal';
 
 @customElement('router-view')
 @noView
-@inject(DOM.Element, Container, ViewSlot, Router, ViewLocator, CompositionTransaction, CompositionEngine)
 export class RouterView {
+
+  static inject() {
+    return [DOM.Element, Container, ViewSlot, Router, ViewLocator, CompositionTransaction, CompositionEngine];
+  }
+
   @bindable swapOrder;
   @bindable layoutView;
   @bindable layoutViewModel;


### PR DESCRIPTION
This is to help DI work smoothly in setup where PLATFORM initialization code is run too late, resulting in `DOM.Element` is still `undefined`