### PR TITLE
fix(route-href): prefix the pathname for fragment hrefs

### DIFF
--- a/src/route-href.js
+++ b/src/route-href.js
@@ -47,6 +47,11 @@ export class RouteHref {
 
         let href = this.router.generate(this.route, this.params);
 
+        // Ensure fragments are created correctly
+        if (href.startsWith('#') && window.location) {
+          href = `${window.location.origin}${window.location.pathname}${window.location.search}${href}`;
+        }
+
         if (this.element.au.controller) {
           this.element.au.controller.viewModel[this.attribute] = href;
         } else {


### PR DESCRIPTION
It seems when a `<base>` tag is used and a url contains something like `index.html?some=query` then the `route-href` sets an incorrect `href` link.

To reproduce:
1. Go to http://next.plnkr.co/edit/UylHNVG2IKkUlBHK
2. Run the preview and navigate to the `http://run.plnkr.co/preview/<ID>/index.html?testing=true` url that is printed in a new tab.
3. Attempt to click on `NEXT PAGE` and see the page force refresh back to `#/next-page` then back to `index.html?testing=true#/home`

This fix adds the windows pathname and search query before the href fragment so that it does not force a new page load.