### PR TITLE
refactor(router-view): revert inherit binding context feat

### DIFF
--- a/src/router-view.ts
+++ b/src/router-view.ts
@@ -82,13 +82,6 @@ export class RouterView {
    */
   layoutModel?: any;
 
-  // /**
-  //  * Indicates whether view composed via instruction given to this <router-view/>
-  //  * should use owning view in scope hierarchy
-  //  * Default value is `true` for compat reason
-  //  */
-  // inheritBindingContext?: any;
-
   /**
    * Element associated with this <router-view/> custom element
    */
@@ -174,7 +167,6 @@ export class RouterView {
     this.viewLocator = viewLocator;
     this.compositionTransaction = compositionTransaction;
     this.compositionEngine = compositionEngine;
-    // this.inheritBindingContext = true;
     // add this <router-view/> to router view ports lookup based on name attribute
     // when this router is the root router-view
     // also trigger AppRouter registerViewPort extra flow
@@ -260,9 +252,6 @@ export class RouterView {
           viewModel,
           viewFactory as ViewFactory
         );
-        // const shouldInheritBindingContext = this.inheritBindingContext;
-        // viewPortComponentBehaviorInstruction.inheritBindingContext = !!(shouldInheritBindingContext && shouldInheritBindingContext !== 'false');
-
         viewPortInstruction.controller = metadata.create(childContainer, viewPortComponentBehaviorInstruction);
 
         if (waitToSwap) {

--- a/src/router-view.ts
+++ b/src/router-view.ts
@@ -82,12 +82,12 @@ export class RouterView {
    */
   layoutModel?: any;
 
-  /**
-   * Indicates whether view composed via instruction given to this <router-view/>
-   * should use owning view in scope hierarchy
-   * Default value is `true` for compat reason
-   */
-  inheritBindingContext?: any;
+  // /**
+  //  * Indicates whether view composed via instruction given to this <router-view/>
+  //  * should use owning view in scope hierarchy
+  //  * Default value is `true` for compat reason
+  //  */
+  // inheritBindingContext?: any;
 
   /**
    * Element associated with this <router-view/> custom element
@@ -174,7 +174,7 @@ export class RouterView {
     this.viewLocator = viewLocator;
     this.compositionTransaction = compositionTransaction;
     this.compositionEngine = compositionEngine;
-    this.inheritBindingContext = true;
+    // this.inheritBindingContext = true;
     // add this <router-view/> to router view ports lookup based on name attribute
     // when this router is the root router-view
     // also trigger AppRouter registerViewPort extra flow
@@ -260,8 +260,8 @@ export class RouterView {
           viewModel,
           viewFactory as ViewFactory
         );
-        const shouldInheritBindingContext = this.inheritBindingContext;
-        viewPortComponentBehaviorInstruction.inheritBindingContext = !!(shouldInheritBindingContext && shouldInheritBindingContext !== 'false');
+        // const shouldInheritBindingContext = this.inheritBindingContext;
+        // viewPortComponentBehaviorInstruction.inheritBindingContext = !!(shouldInheritBindingContext && shouldInheritBindingContext !== 'false');
 
         viewPortInstruction.controller = metadata.create(childContainer, viewPortComponentBehaviorInstruction);
 


### PR DESCRIPTION
@EisenbergEffect I didn't remove the code, so that it's clear what is intended to be done later, and anyone can pick this up easily if interested in case we don't want to wait for compose to be in sync.
